### PR TITLE
Allow setting global config

### DIFF
--- a/lib/template/api.hbs
+++ b/lib/template/api.hbs
@@ -1,13 +1,20 @@
-/* eslint-disable */ 
-import axios from 'axios' 
-import qs from 'qs' 
-let domain = '{{&domain}}' 
-let axiosInstance = axios.create() 
+/* eslint-disable */
+import axios from 'axios'
+import qs from 'qs'
+let domain = '{{&domain}}'
+let config = '{{&config}}'
+let axiosInstance = axios.create()
 export const getDomain = () => {
   return domain
 }
 export const setDomain = ($domain) => {
   domain = $domain
+}
+export const getConfig = () => {
+  return config
+}
+export const setConfig = ($config) => {
+  domain = $config
 }
 export const getAxiosInstance = () => {
   return axiosInstance

--- a/lib/template/api.hbs
+++ b/lib/template/api.hbs
@@ -4,16 +4,16 @@ import qs from 'qs'
 let domain = '{{&domain}}'
 let config = '{{&config}}'
 let axiosInstance = axios.create()
-export const getDomain = () => {
+export const getAPIDomain = () => {
   return domain
 }
-export const setDomain = ($domain) => {
+export const setAPIDomain = ($domain) => {
   domain = $domain
 }
-export const getConfig = () => {
+export const getAPIConfig = () => {
   return config
 }
-export const setConfig = ($config) => {
+export const setAPIConfig = ($config) => {
   domain = $config
 }
 export const getAxiosInstance = () => {

--- a/lib/template/method.hbs
+++ b/lib/template/method.hbs
@@ -10,7 +10,7 @@
 */
 export const {{&methodName}} = function(parameters = {}) {
     const domain = parameters.$domain ? parameters.$domain : getDomain()
-    const config = parameters.$config || { headers: {} }
+    const config = parameters.$domain ? parameters.$config : getConfig()
     let path = '{{&path}}'
     let body
     let queryParameters = {}

--- a/lib/template/method.hbs
+++ b/lib/template/method.hbs
@@ -9,8 +9,8 @@
 {{/parameters}}
 */
 export const {{&methodName}} = function(parameters = {}) {
-    const domain = parameters.$domain ? parameters.$domain : getDomain()
-    const config = parameters.$domain ? parameters.$config : getConfig()
+    const domain = parameters.$domain ? parameters.$domain : getAPIDomain()
+    const config = parameters.$config ? parameters.$config : getAPIConfig()
     let path = '{{&path}}'
     let body
     let queryParameters = {}
@@ -70,7 +70,8 @@ export const {{&methodName}}_TYPE = function () {
 }
 export const {{&methodName}}URL = function(parameters = {}){
     let queryParameters = {}
-    const domain = parameters.$domain ? parameters.$domain : getDomain()
+    const domain = parameters.$domain ? parameters.$domain : getAPIDomain()
+    const config = parameters.$config ? parameters.$config : getAPIConfig()
     let path = '{{&path}}'
     {{#parameters}}
         {{#isQueryParameter}}


### PR DESCRIPTION
It's useful when you need to add a global API key to headers.